### PR TITLE
bump requires_ansible version

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.10"
+requires_ansible: ">=2.16.0"


### PR DESCRIPTION
Bump requires_ansible version to >=2.16.0.
Removes meta-runtime[unsupported-version]: 'requires_ansible' key must refer to a currently supported version such as: >=2.14.0, >=2.15.0, >=2.16.0 ansible-lint warning.

